### PR TITLE
Fix diplomacy dialog game mode / scenario descriptions

### DIFF
--- a/src/Spawner/Spawner.Config.cpp
+++ b/src/Spawner/Spawner.Config.cpp
@@ -50,6 +50,7 @@ void SpawnerConfig::LoadFromINIFile(CCINIClass* pINI)
 		HarvesterTruce = pINI->ReadBool(pSettingsSection, "HarvesterTruce", HarvesterTruce);
 		FogOfWar       = pINI->ReadBool(pSettingsSection, "FogOfWar", FogOfWar);
 		MCVRedeploy    = pINI->ReadBool(pSettingsSection, "MCVRedeploy", MCVRedeploy);
+		/* UIGameMode */ pINI->ReadString(pSettingsSection, "UIGameMode", UIGameMode, UIGameMode, sizeof(UIGameMode));
 	}
 
 	// SaveGame Options

--- a/src/Spawner/Spawner.Config.h
+++ b/src/Spawner/Spawner.Config.h
@@ -77,6 +77,7 @@ public:
 	bool HarvesterTruce;
 	bool FogOfWar;
 	bool MCVRedeploy;
+	char UIGameMode[255];
 
 	// SaveGame Options
 	bool LoadSaveGame;
@@ -136,6 +137,7 @@ public:
 		, HarvesterTruce { false }
 		, FogOfWar { false }
 		, MCVRedeploy { true }
+		, UIGameMode { "" }
 
 		// SaveGame
 		, LoadSaveGame { false }

--- a/src/Spawner/Spawner.Hook.cpp
+++ b/src/Spawner/Spawner.Hook.cpp
@@ -111,3 +111,23 @@ DEFINE_HOOK(0x6843C6, Scenario_LoadWait_SetConnTimeout, 0x5)
 	R->ECX(Spawner::GetConfig()->ConnTimeout);
 	return 0x6843CB;
 }
+
+DEFINE_HOOK(0x658117, DiplomacyDialog_ModeScenarioDescriptions, 0x5)
+{
+	GET(HWND, hDlg, ESI);
+
+	if (SessionClass::Instance->IsSkirmish() || SessionClass::Instance->IsMultiplayer())
+	{
+		HWND hItem = GetDlgItem(hDlg, 1062);
+		wchar_t modeName[256];
+		wsprintfW(modeName, L"%hs", Spawner::GetConfig()->UIGameMode);
+		SendMessageA(hItem, WW_STATIC_SETTEXT, 0, reinterpret_cast<LPARAM>(modeName));
+	}
+
+	HWND hItem = GetDlgItem(hDlg, 1819);
+	wchar_t scenarioName[256];
+	wsprintfW(scenarioName, L"%hs", Spawner::GetConfig()->UIMapName);
+	SendMessageA(hItem, WW_STATIC_SETTEXT, 0, reinterpret_cast<LPARAM>(scenarioName));
+
+	return 0x658168;
+}


### PR DESCRIPTION
Vanilla game correctly displays game mode (only in MP though, I changed it to also display in skirmish) and scenario / map name in diplomacy screen. The values used are not correctly set in spawner, this changes it so that they are, using values already written to spawn.ini by client.