### PR TITLE
Fix remaining issues with statistics file writing

### DIFF
--- a/src/Spawner/Statistics.cpp
+++ b/src/Spawner/Statistics.cpp
@@ -154,70 +154,90 @@ DEFINE_HOOK(0x6C882A, RegisterGameEndTime_CorrectDuration, 0x6)
 
 DEFINE_HOOK(0x448524, BuildingClass_Captured_SendStatistics, 0x7)
 {
-	return IsStatisticsEnabled()
-		? 0x44852D
-		: 0x448559;
+	enum { Send = 0x44852D, DontSend = 0x448559 };
+
+	return IsStatisticsEnabled() || (SessionClass::Instance->GameMode == GameMode::Internet)
+		? Send
+		: DontSend;
 }
 
 DEFINE_HOOK(0x55D0FB, AuxLoop_SendStatistics_1, 0x5)
 {
-	return IsStatisticsEnabled()
-		? 0x55D100
-		: 0x55D123;
+	enum { Send = 0x55D100, DontSend = 0x55D123 };
+
+	return IsStatisticsEnabled() || (SessionClass::Instance->GameMode == GameMode::Internet)
+		? Send
+		: DontSend;
 }
 
 DEFINE_HOOK(0x55D189, AuxLoop_SendStatistics_2, 0x5)
 {
-	return IsStatisticsEnabled()
-		? 0x55D18E
-		: 0x55D1B1;
+	enum { Send = 0x55D18E, DontSend = 0x55D1B1 };
+
+	return IsStatisticsEnabled() || (SessionClass::Instance->GameMode == GameMode::Internet)
+		? Send
+		: DontSend;
 }
 
 DEFINE_HOOK(0x64C7FA, ExecuteDoList_SendStatistics_1, 0x6)
 {
-	return IsStatisticsEnabled()
-		? 0x64C802
-		: 0x64C850;
+	enum { Send = 0x64C802, DontSend = 0x64C850 };
+
+	return IsStatisticsEnabled() || (SessionClass::Instance->GameMode == GameMode::Internet)
+		? Send
+		: DontSend;
 }
 
 DEFINE_HOOK(0x64C81E, ExecuteDoList_SendStatistics_2, 0x6)
 {
-	return IsStatisticsEnabled()
-		? 0x64C826
-		: 0x64C850;
+	enum { Send = 0x64C826, DontSend = 0x64C850 };
+
+	return IsStatisticsEnabled() || (SessionClass::Instance->GameMode == GameMode::Internet)
+		? Send
+		: DontSend;
 }
 
-DEFINE_HOOK(0x647AE8, QueueAIMultiplayer_SendStatistics_1, 0x6)
+DEFINE_HOOK(0x647AE8, QueueAIMultiplayer_SendStatistics_1, 0x7)
 {
-	return IsStatisticsEnabled()
-		? 0x647AF5
-		: 0x6482A6;
+	enum { Send = 0x647AF5, DontSend = 0x6482A6 };
+
+	return IsStatisticsEnabled() || (SessionClass::Instance->GameMode == GameMode::Internet)
+		? Send
+		: DontSend;
 }
 
 DEFINE_HOOK(0x648246, QueueAIMultiplayer_SendStatistics_2, 0x5)
 {
-	return IsStatisticsEnabled()
-		? 0x648257
-		: 0x64825C;
+	enum { Send = 0x648257, DontSend = 0x64825C };
+
+	return IsStatisticsEnabled() || (SessionClass::Instance->GameMode == GameMode::Internet)
+		? Send
+		: DontSend;
 }
 
 DEFINE_HOOK(0x64827D, QueueAIMultiplayer_SendStatistics_3, 0x6)
 {
-	return IsStatisticsEnabled()
-		? 0x648285
-		: 0x6482A6;
+	enum { Send = 0x648285, DontSend = 0x6482A6 };
+
+	return IsStatisticsEnabled() || (SessionClass::Instance->GameMode == GameMode::Internet)
+		? Send
+		: DontSend;
 }
 
-DEFINE_HOOK(0x648081, QueueAIMultiplayer_SendStatistics_4, 0x6)
+DEFINE_HOOK(0x648081, QueueAIMultiplayer_SendStatistics_4, 0x5)
 {
-	return IsStatisticsEnabled()
-		? 0x64808E
-		: 0x648093;
+	enum { Send = 0x64808E, DontSend = 0x648093 };
+
+	return IsStatisticsEnabled() || (SessionClass::Instance->GameMode == GameMode::Internet)
+		? Send
+		: DontSend;
 }
 
 DEFINE_HOOK(0x64B2E4, KickPlayerNow_SendStatistics, 0x7)
 {
-	return IsStatisticsEnabled()
-		? 0x64B2ED
-		: 0x64B352;
+	enum { Send = 0x64B2ED, DontSend = 0x64B352 };
+
+	return IsStatisticsEnabled() || (SessionClass::Instance->GameMode == GameMode::Internet)
+		? Send
+		: DontSend;
 }

--- a/src/Spawner/Statistics.cpp
+++ b/src/Spawner/Statistics.cpp
@@ -156,69 +156,68 @@ DEFINE_HOOK(0x448524, BuildingClass_Captured_SendStatistics, 0x7)
 {
 	return IsStatisticsEnabled()
 		? 0x44852D
-		: 0;
+		: 0x448559;
 }
 
 DEFINE_HOOK(0x55D0FB, AuxLoop_SendStatistics_1, 0x5)
 {
 	return IsStatisticsEnabled()
 		? 0x55D100
-		: 0;
+		: 0x55D123;
 }
 
 DEFINE_HOOK(0x55D189, AuxLoop_SendStatistics_2, 0x5)
 {
 	return IsStatisticsEnabled()
 		? 0x55D18E
-		: 0;
+		: 0x55D1B1;
 }
 
 DEFINE_HOOK(0x64C7FA, ExecuteDoList_SendStatistics_1, 0x6)
 {
 	return IsStatisticsEnabled()
 		? 0x64C802
-		: 0;
+		: 0x64C850;
 }
 
 DEFINE_HOOK(0x64C81E, ExecuteDoList_SendStatistics_2, 0x6)
 {
 	return IsStatisticsEnabled()
 		? 0x64C826
-		: 0;
+		: 0x64C850;
 }
 
 DEFINE_HOOK(0x647AE8, QueueAIMultiplayer_SendStatistics_1, 0x6)
 {
 	return IsStatisticsEnabled()
 		? 0x647AF5
-		: 0;
+		: 0x6482A6;
 }
 
-DEFINE_HOOK(0x64824B, QueueAIMultiplayer_SendStatistics_2, 0x5)
+DEFINE_HOOK(0x648246, QueueAIMultiplayer_SendStatistics_2, 0x5)
 {
-	if (IsStatisticsEnabled())
-		R->EAX(GameMode::Internet);
-
-	return 0;
+	return IsStatisticsEnabled()
+		? 0x648257
+		: 0x64825C;
 }
 
 DEFINE_HOOK(0x64827D, QueueAIMultiplayer_SendStatistics_3, 0x6)
 {
 	return IsStatisticsEnabled()
 		? 0x648285
-		: 0;
+		: 0x6482A6;
 }
 
-DEFINE_HOOK(0x64AB6A, QueueProposeKickPlayer_SendStatistics, 0x7)
+DEFINE_HOOK(0x648081, QueueAIMultiplayer_SendStatistics_4, 0x6)
 {
 	return IsStatisticsEnabled()
-		? 0x64AB73
-		: 0;
+		? 0x64808E
+		: 0x648093;
 }
 
 DEFINE_HOOK(0x64B2E4, KickPlayerNow_SendStatistics, 0x7)
 {
 	return IsStatisticsEnabled()
 		? 0x64B2ED
-		: 0;
+		: 0x64B352;
 }


### PR DESCRIPTION
The previous 'fix' was half-baked and didn't actually address a big issue where it wouldn't actually skip some of the statistics-related code correctly if the condition to write the file wasn't satisfied. While in skirmish or multiplayer this appears to generate no ill effects, it seems to cause singleplayer missions to crash upon completion. This should fix that.

There was also one hook that didn't have anything to do with statistics so I removed it.