### PR TITLE
Allow cloaked units under player control to have SELECT cursor on it when about to select

### DIFF
--- a/src/Misc/Observers.Visibility.cpp
+++ b/src/Misc/Observers.Visibility.cpp
@@ -165,6 +165,9 @@ DEFINE_HOOK(0x4AE62B, DisplayClass_HelpText_Cloak, 0x5)
 	return CheckSensedByHouses;
 }
 
+// Allow showing the select cursor on the object
+DEFINE_JUMP(LJMP, 0x70056C, 0x70059D);
+
 // Show disguised units (Spy and Mirage) for observer
 #pragma region
 // Show spy for observer

--- a/src/Spawner/Ra2Mode.cpp
+++ b/src/Spawner/Ra2Mode.cpp
@@ -173,21 +173,7 @@ void __fastcall Ra2Mode::DetectDisguiseHack::Sensors_RemOfHouse(CellClass* pThis
 #pragma endregion DetectDisguiseHack
 
 // Allow allies to repair on service depot
-DEFINE_HOOK(0x700594, TechnoClass_WhatAction__AllowAlliesRepair, 0x5)
-{
-	if (!Ra2Mode::IsEnabled())
-		return 0;
-
-	GET(TechnoClass*, pThis, ESI);
-	GET(ObjectClass*, pObject, EDI);
-
-	auto const pBuilding = abstract_cast<BuildingClass* const>(pObject);
-	auto const pBuildingOwner = pBuilding ? pBuilding->Owner : nullptr;
-
-	return (pBuildingOwner && pBuildingOwner->IsAlliedWith(pThis))
-		? 0x70059D
-		: 0x7005E6;
-}
+// GOTO Observers.Visibility.cpp
 
 // Allow to repair the BlackHawk Transport on service depot
 #pragma region AllowRepairFlyMZone


### PR DESCRIPTION
Basically at this point it's useless to do all these checks.
What had the program done?
```cpp
if(!this->IsArmed() || !this->Owner->ControlledByCurrentPlayer() || this->Owner==pObject->GetOwningHouse())
    if((this->Spawned || !this->ControlledByCurrentPlayer)
          && pObject->CanBeSelected() &&..)
         return Action::Select;
 
 return Action::None;
```
This is the very end of that function and at this point the first if check is useless, you gotta let me select it