### PR TITLE
Fix invalid call to VirtualProtect

### DIFF
--- a/src/Utilities/Patch.cpp
+++ b/src/Utilities/Patch.cpp
@@ -62,6 +62,8 @@ void Patch::Apply()
 	VirtualProtect(pAddress, this->size, PAGE_EXECUTE_READWRITE, &protect_flag);
 	memcpy(pAddress, this->pData, this->size);
 	VirtualProtect(pAddress, this->size, protect_flag, &protect_flag);
+	// NOTE: Instruction cache flush isn't required on x86. This is just to conform with Win32 API docs.
+	FlushInstructionCache(GetCurrentProcess(), pAddress, this->size);
 }
 
 void Patch::Apply_LJMP(DWORD offset, DWORD pointer)

--- a/src/Utilities/Patch.cpp
+++ b/src/Utilities/Patch.cpp
@@ -61,7 +61,7 @@ void Patch::Apply()
 	DWORD protect_flag;
 	VirtualProtect(pAddress, this->size, PAGE_EXECUTE_READWRITE, &protect_flag);
 	memcpy(pAddress, this->pData, this->size);
-	VirtualProtect(pAddress, this->size, protect_flag, NULL);
+	VirtualProtect(pAddress, this->size, protect_flag, &protect_flag);
 }
 
 void Patch::Apply_LJMP(DWORD offset, DWORD pointer)


### PR DESCRIPTION
VirtualProtect fails if fourth argument is NULL, see: https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualprotect

On some versions of wine this leads to null pointer dereference and crash.