### PR TITLE
Allow toggling whether or not special house is ally to all players

### DIFF
--- a/src/Spawner/Spawner.Config.cpp
+++ b/src/Spawner/Spawner.Config.cpp
@@ -30,23 +30,24 @@ void SpawnerConfig::LoadFromINIFile(CCINIClass* pINI)
 		return;
 
 	{ // Game Mode Options
-		MPModeIndex    = pINI->ReadInteger(pSettingsSection, "GameMode", MPModeIndex);
-		Bases          = pINI->ReadBool(pSettingsSection, "Bases", Bases);
-		Credits        = pINI->ReadInteger(pSettingsSection, "Credits", Credits);
-		BridgeDestroy  = pINI->ReadBool(pSettingsSection, "BridgeDestroy", BridgeDestroy);
-		Crates         = pINI->ReadBool(pSettingsSection, "Crates", Crates);
-		ShortGame      = pINI->ReadBool(pSettingsSection, "ShortGame", ShortGame);
-		SuperWeapons   = pINI->ReadBool(pSettingsSection, "Superweapons", SuperWeapons);
-		BuildOffAlly   = pINI->ReadBool(pSettingsSection, "BuildOffAlly", BuildOffAlly);
-		GameSpeed      = pINI->ReadInteger(pSettingsSection, "GameSpeed", GameSpeed);
-		MultiEngineer  = pINI->ReadBool(pSettingsSection, "MultiEngineer", MultiEngineer);
-		UnitCount      = pINI->ReadInteger(pSettingsSection, "UnitCount", UnitCount);
-		AIPlayers      = pINI->ReadInteger(pSettingsSection, "AIPlayers", AIPlayers);
-		AIDifficulty   = pINI->ReadInteger(pSettingsSection, "AIDifficulty", AIDifficulty);
-		AlliesAllowed  = pINI->ReadBool(pSettingsSection, "AlliesAllowed", AlliesAllowed);
-		HarvesterTruce = pINI->ReadBool(pSettingsSection, "HarvesterTruce", HarvesterTruce);
-		FogOfWar       = pINI->ReadBool(pSettingsSection, "FogOfWar", FogOfWar);
-		MCVRedeploy    = pINI->ReadBool(pSettingsSection, "MCVRedeploy", MCVRedeploy);
+		MPModeIndex        = pINI->ReadInteger(pSettingsSection, "GameMode", MPModeIndex);
+		Bases              = pINI->ReadBool(pSettingsSection, "Bases", Bases);
+		Credits            = pINI->ReadInteger(pSettingsSection, "Credits", Credits);
+		BridgeDestroy      = pINI->ReadBool(pSettingsSection, "BridgeDestroy", BridgeDestroy);
+		Crates             = pINI->ReadBool(pSettingsSection, "Crates", Crates);
+		ShortGame          = pINI->ReadBool(pSettingsSection, "ShortGame", ShortGame);
+		SuperWeapons       = pINI->ReadBool(pSettingsSection, "Superweapons", SuperWeapons);
+		BuildOffAlly       = pINI->ReadBool(pSettingsSection, "BuildOffAlly", BuildOffAlly);
+		GameSpeed          = pINI->ReadInteger(pSettingsSection, "GameSpeed", GameSpeed);
+		MultiEngineer      = pINI->ReadBool(pSettingsSection, "MultiEngineer", MultiEngineer);
+		UnitCount          = pINI->ReadInteger(pSettingsSection, "UnitCount", UnitCount);
+		AIPlayers          = pINI->ReadInteger(pSettingsSection, "AIPlayers", AIPlayers);
+		AIDifficulty       = pINI->ReadInteger(pSettingsSection, "AIDifficulty", AIDifficulty);
+		AlliesAllowed      = pINI->ReadBool(pSettingsSection, "AlliesAllowed", AlliesAllowed);
+		HarvesterTruce     = pINI->ReadBool(pSettingsSection, "HarvesterTruce", HarvesterTruce);
+		FogOfWar           = pINI->ReadBool(pSettingsSection, "FogOfWar", FogOfWar);
+		MCVRedeploy        = pINI->ReadBool(pSettingsSection, "MCVRedeploy", MCVRedeploy);
+		SpecialHouseIsAlly = pINI->ReadBool(pSettingsSection, "SpecialHouseIsAlly", SpecialHouseIsAlly);
 
 		if (INIClassExt::ReadString_WithoutAresHook(pINI, pSettingsSection, "UIGameMode", "", Main::readBuffer, sizeof(Main::readBuffer)) > 0)
 			MultiByteToWideChar(CP_UTF8, 0, Main::readBuffer, strlen(Main::readBuffer), UIGameMode, std::size(UIGameMode));

--- a/src/Spawner/Spawner.Config.h
+++ b/src/Spawner/Spawner.Config.h
@@ -93,6 +93,7 @@ public:
 	bool FogOfWar;
 	bool MCVRedeploy;
 	wchar_t UIGameMode[60];
+	bool SpecialHouseIsAlly;
 
 	// SaveGame Options
 	bool LoadSaveGame;
@@ -163,6 +164,7 @@ public:
 		, FogOfWar { false }
 		, MCVRedeploy { true }
 		, UIGameMode { L"" }
+		, SpecialHouseIsAlly { true }
 
 		// SaveGame
 		, LoadSaveGame { false }

--- a/src/Spawner/Spawner.Hook.cpp
+++ b/src/Spawner/Spawner.Hook.cpp
@@ -41,9 +41,9 @@ DEFINE_HOOK(0x6BD7C5, WinMain_SpawnerInit, 0x6)
 			Patch::Apply_CALL(0x68745E, Spawner::AssignHouses); // Read_Scenario_INI
 			Patch::Apply_CALL(0x68ACFF, Spawner::AssignHouses); // ScenarioClass::Read_INI
 
-			Patch::Apply_LJMP(0x5D74A0, 0x5D7570); // MPGameModeClass_AllyTeams
-			Patch::Apply_LJMP(0x501721, 0x501736); // HouseClass_ComputerParanoid
-			Patch::Apply_LJMP(0x686A9E, 0x686AC6); // RemoveAIPlayers
+			Patch::Apply_LJMP(0x5D74A0, 0x5D7570);   // MPGameModeClass_AllyTeams
+			Patch::Apply_LJMP(0x501721, 0x501736);   // HouseClass_ComputerParanoid
+			//Patch::Apply_LJMP(0x686A9E, 0x686AC6); // ReadScenario_InitSomeThings - Moved to a hook to allow conditional toggling of Special house's alliances.
 		}
 
 		{ // NetHack
@@ -238,3 +238,11 @@ DEFINE_HOOK(0x67E6DA, LoadGame_AfterInit, 0x6)
 }
 
 #pragma endregion
+
+DEFINE_HOOK(0x686A9E, ReadScenario_InitSomeThings_SpecialHouseIsAlly, 0x6)
+{
+	if (Spawner::GetConfig()->SpecialHouseIsAlly)
+		return 0;
+
+	return 0x686AC6;
+}


### PR DESCRIPTION
Spawner has for some reason disabled a piece of code that in vanilla game makes house with ID `Special` mutually ally with all other players present in scenario. Intention behind disabling this code is unclear, likely impossible to decipher at this time and it is possibly a mistake. This PR restores it by default and allows restoring the old, questionable spawner behaviour by setting `SpecialHouseIsAlly` to false in `spawn.ini`.