### PR TITLE
DisableChat spawn.ini option for ladder

### DIFF
--- a/src/Misc/InGameChat.cpp
+++ b/src/Misc/InGameChat.cpp
@@ -20,6 +20,7 @@
 #include <Spawner/Spawner.h>
 #include <Utilities/Macro.h>
 #include <HouseClass.h>
+#include <MessageListClass.h>
 #include <Unsorted.h>
 
 // This corrects the processing of Unicode player names
@@ -40,20 +41,15 @@ struct GlobalPacket_NetMessage
 };
 #pragma pack(pop)
 
-// Continuously enforce DisableChat by resetting ChatMask every frame,
-// preventing players from re-enabling chat via the alliances menu.
-DEFINE_HOOK(0x55DDA5, MainLoop_AfterRender__DisableChat, 0x5)
+void __fastcall MainLoop_AfterRender_DisableChat(MessageListClass* pMessageList, DWORD)
 {
-	if (!Spawner::Enabled)
-		return 0;
+	pMessageList->Manage();
 
-	if (Spawner::GetConfig()->DisableChat)
-	{
-		for (int i = 0; i < 8; i++)
-			Game::ChatMask[i] = false;
-	}
+	if (!Spawner::Enabled || !Spawner::GetConfig()->DisableChat)
+		return;
 
-	return 0;
+	for (int i = 0; i < 8; ++i)
+		Game::ChatMask[i] = false;
 }
 
 // Don't send message to others when DisableChat is active.

--- a/src/Misc/InGameChat.cpp
+++ b/src/Misc/InGameChat.cpp
@@ -56,8 +56,20 @@ void __fastcall MainLoop_AfterRender_DisableChat(MessageListClass* pMessageList,
 // Mirrors: hack 0x0055EF38, 0x0055EF3E in chat_disable.asm
 DEFINE_HOOK(0x55EF38, MessageSend_DisableChat, 0x6)
 {
+	static int LastDisableChatFeedbackFrame = -1000;
+
 	if (Spawner::Enabled && Spawner::GetConfig()->DisableChat)
+	{
+		const int currentFrame = Unsorted::CurrentFrame;
+
+		if (currentFrame - LastDisableChatFeedbackFrame >= 90)
+		{
+			MessageListClass::Instance.PrintMessage(L"Chat is disabled. Message not sent.");
+			LastDisableChatFeedbackFrame = currentFrame;
+		}
+
 		return 0x55F056; // skip the send
+	}
 
 	return 0; // execute original: cmp edi, ebx; mov [esp+0x14], ebx
 }

--- a/src/Misc/InGameChat.cpp
+++ b/src/Misc/InGameChat.cpp
@@ -41,12 +41,6 @@ struct GlobalPacket_NetMessage
 	byte CRC;
 };
 
-struct DiplomacyChatToggleState
-{
-	DEFINE_REFERENCE(DiplomacyChatToggleState, Instance, 0xA8D108u);
-
-	byte ByHouse[8];
-};
 #pragma pack(pop)
 
 static bool inline IsDisableChatEnabled()
@@ -123,10 +117,7 @@ DEFINE_HOOK(0x55DDA5, MainLoop_AfterRender_DisableChat, 0x5)
 	if (IsDisableChatEnabled())
 	{
 		for (int i = 0; i < 8; ++i)
-		{
-			DiplomacyChatToggleState::Instance.ByHouse[i] = 0;
 			Game::ChatMask[i] = false;
-		}
 	}
 
 	return 0x55DDAA;

--- a/src/Misc/InGameChat.cpp
+++ b/src/Misc/InGameChat.cpp
@@ -58,6 +58,9 @@ DEFINE_HOOK(0x55EF38, MessageSend_DisableChat, 0x6)
 	{
 		const int currentFrame = Unsorted::CurrentFrame;
 
+		if (currentFrame < LastDisableChatFeedbackFrame)
+			LastDisableChatFeedbackFrame = -1000; // new match started
+
 		if (currentFrame - LastDisableChatFeedbackFrame >= 90)
 		{
 			MessageListClass::Instance.PrintMessage(L"Chat is disabled. Message not sent.");

--- a/src/Spawner/Spawner.Config.cpp
+++ b/src/Spawner/Spawner.Config.cpp
@@ -116,6 +116,7 @@ void SpawnerConfig::LoadFromINIFile(CCINIClass* pINI)
 		ContinueWithoutHumans    = pINI->ReadBool(pSettingsSection, "ContinueWithoutHumans", ContinueWithoutHumans);
 		DefeatedBecomesObserver  = pINI->ReadBool(pSettingsSection, "DefeatedBecomesObserver", DefeatedBecomesObserver);
 		Observer_ShowAIOnSidebar = pINI->ReadBool(pSettingsSection, "Observer.ShowAIOnSidebar", Observer_ShowAIOnSidebar);
+		DisableChat              = pINI->ReadBool(pSettingsSection, "DisableChat", DisableChat);
 	}
 }
 

--- a/src/Spawner/Spawner.Config.h
+++ b/src/Spawner/Spawner.Config.h
@@ -145,6 +145,7 @@ public:
 	bool ContinueWithoutHumans;
 	bool DefeatedBecomesObserver;
 	bool Observer_ShowAIOnSidebar;
+	bool DisableChat;
 
 	SpawnerConfig() // default values
 		// Game Mode Options
@@ -238,6 +239,7 @@ public:
 		, ContinueWithoutHumans { false }
 		, DefeatedBecomesObserver { false }
 		, Observer_ShowAIOnSidebar { false }
+		, DisableChat { false }
 	{ }
 
 	void LoadFromINIFile(CCINIClass* pINI);

--- a/src/Spawner/Spawner.Hook.cpp
+++ b/src/Spawner/Spawner.Hook.cpp
@@ -27,6 +27,8 @@
 #include <Utilities/Macro.h>
 #include <Unsorted.h>
 
+void __fastcall MainLoop_AfterRender_DisableChat(class MessageListClass* pMessageList, DWORD);
+
 DEFINE_HOOK(0x6BD7C5, WinMain_SpawnerInit, 0x6)
 {
 	if (Spawner::Enabled)
@@ -60,6 +62,9 @@ DEFINE_HOOK(0x6BD7C5, WinMain_SpawnerInit, 0x6)
 			Patch::Apply_LJMP(0x553321, 0x5533C5); // LoadProgressMgr_Draw_CooperativeDescription
 			Patch::Apply_LJMP(0x55D0DF, 0x55D0E8); // AuxLoop_Cooperative_EndgameCrashFix
 		}
+
+		// Disable chat from alliances menu when DisableChat is enabled.
+		Patch::Apply_CALL(0x55DDA5, MainLoop_AfterRender_DisableChat); // MainLoop_AfterRender
 
 		// Set ConnTimeout
 		Patch::Apply_TYPED<int>(0x6843C7, { Spawner::GetConfig()->ConnTimeout }); // Scenario_Load_Wait

--- a/src/Spawner/Spawner.Hook.cpp
+++ b/src/Spawner/Spawner.Hook.cpp
@@ -27,8 +27,6 @@
 #include <Utilities/Macro.h>
 #include <Unsorted.h>
 
-void __fastcall MainLoop_AfterRender_DisableChat(class MessageListClass* pMessageList, DWORD);
-
 DEFINE_HOOK(0x6BD7C5, WinMain_SpawnerInit, 0x6)
 {
 	if (Spawner::Enabled)
@@ -62,9 +60,6 @@ DEFINE_HOOK(0x6BD7C5, WinMain_SpawnerInit, 0x6)
 			Patch::Apply_LJMP(0x553321, 0x5533C5); // LoadProgressMgr_Draw_CooperativeDescription
 			Patch::Apply_LJMP(0x55D0DF, 0x55D0E8); // AuxLoop_Cooperative_EndgameCrashFix
 		}
-
-		// Disable chat from alliances menu when DisableChat is enabled.
-		Patch::Apply_CALL(0x55DDA5, MainLoop_AfterRender_DisableChat); // MainLoop_AfterRender
 
 		// Set ConnTimeout
 		Patch::Apply_TYPED<int>(0x6843C7, { Spawner::GetConfig()->ConnTimeout }); // Scenario_Load_Wait


### PR DESCRIPTION
Potential solution to issue #60 

Mirrors the DisableChat functionality of the older yr spawner.

Pull rquest to remain open and used for testing nightlybuild dll's. 