### PR TITLE
Port CnCNet YR fixes to mainline: desyncs, open-top cloak, DisableChat

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,16 @@ Credits
   - Beacon crash fix for multiplayer save/load
   - Game speed slider toggle
   - Fake multiplayer flag
+- **[EJ](https://github.com/11EJDE11)**
+  - Whole lot of desync fixes
 - **[ZivDero](https://github.com/ZivDero)**
   - Handicaps (difficulty & credits) support
 - **[Starkku](https://github.com/Starkku)**
   - Allow customizing whether or not special house is ally to all players via spawn.ini option (#51)
 - **[RAZER](https://github.com/CnCRAZER)**
   - Game speed slider toggle
+  - Revert of Battle Fortress cloak changes for CnCNet YR
+  - Ability to disable ingame chat
 - **[TaranDahl](https://github.com/TaranDahl)**
   - Porting of multiplayer save/load
   - Porting of autosaves

--- a/Spawner.vcxproj
+++ b/Spawner.vcxproj
@@ -34,7 +34,9 @@
     <!-- Misc -->
     <ClCompile Include="$(ThisDir)\src\Misc\Bugfixes.cpp" />
     <ClCompile Include="$(ThisDir)\src\Misc\Bugfixes.Blowfish.cpp" />
+    <ClCompile Include="$(ThisDir)\src\Misc\Bugfixes.Desyncs.cpp" />
     <ClCompile Include="$(ThisDir)\src\Misc\Bugfixes.ClampTacticalPos.cpp" />
+    <ClCompile Include="$(ThisDir)\src\Misc\Bugfixes.OpenTopCloak.cpp" />
     <ClCompile Include="$(ThisDir)\src\Misc\Bugfixes.CommonCrashes.cpp" />
     <ClCompile Include="$(ThisDir)\src\Misc\Bugfixes.ExceptionCatch.cpp" />
     <ClCompile Include="$(ThisDir)\src\Misc\Bugfixes.IsoMapPack5Limit.cpp" />

--- a/src/Misc/Bugfixes.Desyncs.cpp
+++ b/src/Misc/Bugfixes.Desyncs.cpp
@@ -1,0 +1,349 @@
+/**
+*  yrpp-spawner
+*
+*  Copyright(C) 2022-present CnCNet
+*
+*  This program is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation, either version 3 of the License, or
+*  (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with this program.If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Multiplayer desync fixes for missing CellClass::RecalcAttributes calls.
+//
+// CellClass::RecalcAttributes derives LandType/Passability from
+// a cell's iso tile and overlay. Several game code paths clear overlays
+// (crates, flags, veinholes, bridges) without calling RecalcAttributes,
+// leaving LandType stale. This diverges between players when an aircraft
+// passes over the cell(s) which later leads to pathfinding differences.
+
+#ifdef IS_CNCNET_YR_VER
+
+#include <Utilities/Macro.h>
+#include <CellClass.h>
+#include <FootClass.h>
+#include <MapClass.h>
+#include <TechnoClass.h>
+
+// ============================================================
+// Aircraft shadow desync fix
+// ============================================================
+// AircraftClass::Draw_It temporarily calls Set_Height(0) before drawing the
+// shadow, which triggers MapClass::Place_Down and Pick_Up, which call
+// RecalcAttributes. This only runs for players who can see the aircraft,
+// causing LandType to diverge based on fog-of-war state.
+// Fix: no-op all three Set_Height calls during shadow drawing.
+// 0x5F4300 = ObjectClass::Record_The_Kill_House (empty body, safe NOP target).
+DEFINE_JUMP(CALL6, 0x4147D5, 0x5F4300); // Set_Height bridge path
+DEFINE_JUMP(CALL6, 0x4147F3, 0x5F4300); // Set_Height non-bridge path
+DEFINE_JUMP(CALL6, 0x4148AB, 0x5F4300); // Set_Height restore
+
+// ============================================================
+// Crate removal RecalcAttributes
+// ============================================================
+
+// Single-player crate removal path.
+DEFINE_HOOK(0x4A1BEF, CrateClass_Get_Crate_RecalcAttributes, 0x6)
+{
+	GET(CellClass*, pCell, EBX);
+	pCell->RecalcAttributes(DWORD(-1));
+	return 0;
+}
+
+// Multiplayer crate removal path.
+DEFINE_HOOK(0x56C1DA, MapClass_Remove_Crate_RecalcAttributes, 0x6)
+{
+	GET(CellClass*, pCell, EBX);
+	pCell->RecalcAttributes(DWORD(-1));
+	return 0;
+}
+
+// ============================================================
+// Flag removal RecalcAttributes
+// ============================================================
+
+// HouseClass::Flag_Remove: clears the flag home cell overlay without RecalcAttributes.
+DEFINE_HOOK(0x4FBF3C, HouseClass_Flag_Remove_RecalcAttributes, 0x5)
+{
+	GET(CellClass*, pCell, EAX);
+	pCell->RecalcAttributes(DWORD(-1));
+	return 0;
+}
+
+// ============================================================
+// Veinhole constructor RecalcAttributes
+// ============================================================
+
+// VeinholeMonsterClass constructor directly writes SlopeIndex, IsoTileTypeIndex,
+// Height, and Level for a 3x3 cell grid without calling RecalcAttributes.
+// Hook after the last per-cell write (Level) each iteration to fix all 9 cells.
+DEFINE_HOOK(0x74C775, VeinholeMonster_Constructor_RecalcAttributes, 0x6)
+{
+	GET(CellClass*, pCell, EAX);
+	pCell->Level = (char)R->DL(); // write Level-1 before RecalcAttributes
+	pCell->RecalcAttributes(DWORD(-1));
+	MapClass::Instance.ResetZones(pCell->MapCoords);
+	MapClass::Instance.RecalculateSubZones(pCell->MapCoords);
+	return 0x74C77B;
+}
+
+// ============================================================
+// Bridge RecalcAttributes helpers
+// ============================================================
+
+// Called when a bridge section overlay is fully removed (OverlayTypeIndex = -1).
+static void BridgeCellDestroyed(CellClass* pCell)
+{
+	pCell->RecalcAttributes(DWORD(-1));
+	MapClass::Instance.ResetZones(pCell->MapCoords);
+	MapClass::Instance.RecalculateSubZones(pCell->MapCoords);
+}
+
+// Called when a bridge cell's damage state changes (OverlayData only, overlay
+// type index still valid).
+static void BridgeCellDamaged(CellClass* pCell)
+{
+	pCell->RecalcAttributes(DWORD(-1));
+	MapClass::Instance.RecalculateZones(pCell->MapCoords);
+	MapClass::Instance.RecalculateSubZones(pCell->MapCoords);
+}
+
+// ============================================================
+// Bridge hooks - Group A: ESI = CellClass*, OverlayTypeIndex = -1 (7 bytes)
+// ============================================================
+
+DEFINE_HOOK(0x56EFF2, MapBridge_56EF50_RecalcCell, 0x7)
+{
+	GET(CellClass*, pCell, ESI);
+	pCell->OverlayTypeIndex = -1;
+	BridgeCellDestroyed(pCell);
+	return 0x56EFF9;
+}
+
+DEFINE_HOOK(0x56F392, MapBridge_56F2F0_RecalcCell, 0x7)
+{
+	GET(CellClass*, pCell, ESI);
+	pCell->OverlayTypeIndex = -1;
+	BridgeCellDestroyed(pCell);
+	return 0x56F399;
+}
+
+DEFINE_HOOK(0x56F956, MapBridge_Destroy_56F8B0_RecalcCell, 0x7)
+{
+	GET(CellClass*, pCell, ESI);
+	pCell->OverlayTypeIndex = -1;
+	BridgeCellDestroyed(pCell);
+	return 0x56F95D;
+}
+
+DEFINE_HOOK(0x56FD26, MapBridge_56FCC0_RecalcCell, 0x7)
+{
+	GET(CellClass*, pCell, ESI);
+	pCell->OverlayTypeIndex = -1;
+	BridgeCellDestroyed(pCell);
+	return 0x56FD2D;
+}
+
+DEFINE_HOOK(0x5721C2, MapBridge_572100_RecalcCell_A, 0x7)
+{
+	GET(CellClass*, pCell, ESI);
+	pCell->OverlayTypeIndex = -1;
+	BridgeCellDestroyed(pCell);
+	return 0x5721C9;
+}
+
+DEFINE_HOOK(0x5724E2, MapBridge_572480_RecalcCell, 0x7)
+{
+	GET(CellClass*, pCell, ESI);
+	pCell->OverlayTypeIndex = -1;
+	BridgeCellDestroyed(pCell);
+	return 0x5724E9;
+}
+
+DEFINE_HOOK(0x572882, MapBridge_572820_RecalcCell, 0x7)
+{
+	GET(CellClass*, pCell, ESI);
+	pCell->OverlayTypeIndex = -1;
+	BridgeCellDestroyed(pCell);
+	return 0x572889;
+}
+
+DEFINE_HOOK(0x572E46, MapBridge_572DE0_RecalcCell, 0x7)
+{
+	GET(CellClass*, pCell, ESI);
+	pCell->OverlayTypeIndex = -1;
+	BridgeCellDestroyed(pCell);
+	return 0x572E4D;
+}
+
+DEFINE_HOOK(0x573216, MapBridge_5731B0_RecalcCell, 0x7)
+{
+	GET(CellClass*, pCell, ESI);
+	pCell->OverlayTypeIndex = -1;
+	BridgeCellDestroyed(pCell);
+	return 0x57321D;
+}
+
+DEFINE_HOOK(0x57779F, MapBridge_577740_RecalcCell, 0x7)
+{
+	GET(CellClass*, pCell, ESI);
+	pCell->OverlayTypeIndex = -1;
+	BridgeCellDestroyed(pCell);
+	return 0x5777A6;
+}
+
+DEFINE_HOOK(0x5778BB, MapBridge_577860_RecalcCell, 0x7)
+{
+	GET(CellClass*, pCell, ESI);
+	pCell->OverlayTypeIndex = -1;
+	BridgeCellDestroyed(pCell);
+	return 0x5778C2;
+}
+
+// ============================================================
+// Bridge hooks - Group B: EAX = CellClass*, OverlayData change (7 bytes)
+// ============================================================
+
+DEFINE_HOOK(0x56F712, MapBridge_56F690_Damaged_EAX_F1, 0x7)
+{
+	GET(CellClass*, pCell, EAX);
+	pCell->OverlayData = 0xF;
+	BridgeCellDamaged(pCell);
+	return 0x56F719;
+}
+
+DEFINE_HOOK(0x56F71B, MapBridge_56F690_Damaged_EAX_E1, 0x7)
+{
+	GET(CellClass*, pCell, EAX);
+	pCell->OverlayData = 0xE;
+	BridgeCellDamaged(pCell);
+	return 0x56F722;
+}
+
+DEFINE_HOOK(0x56F822, MapBridge_56F7A0_Damaged_EAX_F2, 0x7)
+{
+	GET(CellClass*, pCell, EAX);
+	pCell->OverlayData = 0xF;
+	BridgeCellDamaged(pCell);
+	return 0x56F829;
+}
+
+DEFINE_HOOK(0x56F82B, MapBridge_56F7A0_Damaged_EAX_D2, 0x7)
+{
+	GET(CellClass*, pCell, EAX);
+	pCell->OverlayData = 0xD;
+	BridgeCellDamaged(pCell);
+	return 0x56F832;
+}
+
+DEFINE_HOOK(0x572C02, MapBridge_572BC0_Damaged_EAX_F3, 0x7)
+{
+	GET(CellClass*, pCell, EAX);
+	pCell->OverlayData = 0xF;
+	BridgeCellDamaged(pCell);
+	return 0x572C09;
+}
+
+DEFINE_HOOK(0x572C0B, MapBridge_572BC0_Damaged_EAX_E3, 0x7)
+{
+	GET(CellClass*, pCell, EAX);
+	pCell->OverlayData = 0xE;
+	BridgeCellDamaged(pCell);
+	return 0x572C12;
+}
+
+DEFINE_HOOK(0x572D12, MapBridge_572CD0_Damaged_EAX_F4, 0x7)
+{
+	GET(CellClass*, pCell, EAX);
+	pCell->OverlayData = 0xF;
+	BridgeCellDamaged(pCell);
+	return 0x572D19;
+}
+
+DEFINE_HOOK(0x572D1B, MapBridge_572CD0_Damaged_EAX_D4, 0x7)
+{
+	GET(CellClass*, pCell, EAX);
+	pCell->OverlayData = 0xD;
+	BridgeCellDamaged(pCell);
+	return 0x572D22;
+}
+
+// ============================================================
+// Bridge hooks - Group C: ESI = CellClass*, OverlayData change (7 bytes)
+// ============================================================
+
+DEFINE_HOOK(0x572101, MapBridge_572100_Damaged_ESI, 0x7)
+{
+	GET(CellClass*, pCell, ESI);
+	pCell->OverlayData = 0xF;
+	BridgeCellDamaged(pCell);
+	return 0x572108;
+}
+
+DEFINE_HOOK(0x5777FC, MapBridge_577740_Damaged_ESI, 0x7)
+{
+	GET(CellClass*, pCell, ESI);
+	pCell->OverlayData = 0xF;
+	BridgeCellDamaged(pCell);
+	return 0x577803;
+}
+
+// ============================================================
+// Bridge hooks - Group D: EBP = CellClass*, OverlayTypeIndex = -1 (7 bytes)
+// ============================================================
+
+// VeinholeMonsterClass area bridge cell clear (0x74CBEE).
+DEFINE_HOOK(0x74CBEE, VeinholeArea_Bridge_RecalcCell, 0x7)
+{
+	GET(CellClass*, pCell, EBP);
+	pCell->OverlayTypeIndex = -1;
+	BridgeCellDestroyed(pCell);
+	return 0x74CBF5;
+}
+
+// ============================================================
+// Bridge hooks - Group E: ESI = CellClass*, OverlayData + OverlayTypeIndex (10 bytes)
+// ============================================================
+
+DEFINE_HOOK(0x576721, MapBridge_576200_RecalcCell, 0xA)
+{
+	GET(CellClass*, pCell, ESI);
+	pCell->OverlayData = 0;
+	pCell->OverlayTypeIndex = -1;
+	BridgeCellDestroyed(pCell);
+	return 0x57672B;
+}
+
+// Fix a desync with invisible objects
+// see 1) on https://modenc2.markjfox.net/Reconnection_Error
+DEFINE_HOOK(0x70F1E3, TechnoClass_DrawBehind_InvisibleDesyncFix, 0x8)
+{
+    enum { CreateBehindAnim = 0x70F1EB, SkipBehindAnim = 0x70F659 };
+
+    GET(VisualType, visual, EAX);
+    GET(TechnoClass*, pThis, ESI);
+
+    if (visual != VisualType::Normal) // original gate: only proceed when visually normal
+        return SkipBehindAnim;
+
+    if (pThis->GetTechnoType()->Invisible) // desync fix: owner-dependent VISUAL_NORMAL
+        return SkipBehindAnim;
+
+    return CreateBehindAnim;
+}
+
+// Fixes a desync caused by a check for shrouding at a specific cell
+// Sets Session.MPGameMode->SkipCheatCheck() to true
+// TODO: Remove when Phobos Release is greater than 0.4.0.2
+// as that has a better fix for this.
+DEFINE_PATCH(0x5C0E30, 0xB0, 0x01)
+
+#endif

--- a/src/Misc/Bugfixes.Desyncs.cpp
+++ b/src/Misc/Bugfixes.Desyncs.cpp
@@ -332,18 +332,18 @@ DEFINE_HOOK(0x576721, MapBridge_576200_RecalcCell, 0xA)
 // see 1) on https://modenc2.markjfox.net/Reconnection_Error
 DEFINE_HOOK(0x70F1E3, TechnoClass_DrawBehind_InvisibleDesyncFix, 0x8)
 {
-    enum { CreateBehindAnim = 0x70F1EB, SkipBehindAnim = 0x70F659 };
+	enum { CreateBehindAnim = 0x70F1EB, SkipBehindAnim = 0x70F659 };
 
-    GET(VisualType, visual, EAX);
-    GET(TechnoClass*, pThis, ESI);
+	GET(VisualType, visual, EAX);
+	GET(TechnoClass*, pThis, ESI);
 
-    if (visual != VisualType::Normal) // original gate: only proceed when visually normal
-        return SkipBehindAnim;
+	if (visual != VisualType::Normal) // original gate: only proceed when visually normal
+		return SkipBehindAnim;
 
-    if (pThis->GetTechnoType()->Invisible) // desync fix: owner-dependent VISUAL_NORMAL
-        return SkipBehindAnim;
+	if (pThis->GetTechnoType()->Invisible) // desync fix: owner-dependent VISUAL_NORMAL
+		return SkipBehindAnim;
 
-    return CreateBehindAnim;
+	return CreateBehindAnim;
 }
 
 // Fixes a desync caused by a check for shrouding at a specific cell

--- a/src/Misc/Bugfixes.Desyncs.cpp
+++ b/src/Misc/Bugfixes.Desyncs.cpp
@@ -31,6 +31,13 @@
 #include <MapClass.h>
 #include <TechnoClass.h>
 
+// CellClass::RecalcAttributes takes a cell level; -1 means "recalc but keep the
+// current level unchanged" (see CellClass.h).
+static constexpr int KeepCellLevel = -1;
+
+// CellClass::OverlayTypeIndex sentinel meaning "no overlay present on this cell".
+static constexpr int NoOverlay = -1;
+
 // ============================================================
 // Aircraft shadow desync fix
 // ============================================================
@@ -52,7 +59,7 @@ DEFINE_JUMP(CALL6, 0x4148AB, 0x5F4300); // Set_Height restore
 DEFINE_HOOK(0x4A1BEF, CrateClass_Get_Crate_RecalcAttributes, 0x6)
 {
 	GET(CellClass*, pCell, EBX);
-	pCell->RecalcAttributes(DWORD(-1));
+	pCell->RecalcAttributes(KeepCellLevel);
 	return 0;
 }
 
@@ -60,7 +67,7 @@ DEFINE_HOOK(0x4A1BEF, CrateClass_Get_Crate_RecalcAttributes, 0x6)
 DEFINE_HOOK(0x56C1DA, MapClass_Remove_Crate_RecalcAttributes, 0x6)
 {
 	GET(CellClass*, pCell, EBX);
-	pCell->RecalcAttributes(DWORD(-1));
+	pCell->RecalcAttributes(KeepCellLevel);
 	return 0;
 }
 
@@ -69,10 +76,11 @@ DEFINE_HOOK(0x56C1DA, MapClass_Remove_Crate_RecalcAttributes, 0x6)
 // ============================================================
 
 // HouseClass::Flag_Remove: clears the flag home cell overlay without RecalcAttributes.
+// Unused, but kept for correctness should such a mode be used.
 DEFINE_HOOK(0x4FBF3C, HouseClass_Flag_Remove_RecalcAttributes, 0x5)
 {
 	GET(CellClass*, pCell, EAX);
-	pCell->RecalcAttributes(DWORD(-1));
+	pCell->RecalcAttributes(KeepCellLevel);
 	return 0;
 }
 
@@ -87,7 +95,7 @@ DEFINE_HOOK(0x74C775, VeinholeMonster_Constructor_RecalcAttributes, 0x6)
 {
 	GET(CellClass*, pCell, EAX);
 	pCell->Level = (char)R->DL(); // write Level-1 before RecalcAttributes
-	pCell->RecalcAttributes(DWORD(-1));
+	pCell->RecalcAttributes(KeepCellLevel);
 	MapClass::Instance.ResetZones(pCell->MapCoords);
 	MapClass::Instance.RecalculateSubZones(pCell->MapCoords);
 	return 0x74C77B;
@@ -100,7 +108,7 @@ DEFINE_HOOK(0x74C775, VeinholeMonster_Constructor_RecalcAttributes, 0x6)
 // Called when a bridge section overlay is fully removed (OverlayTypeIndex = -1).
 static void BridgeCellDestroyed(CellClass* pCell)
 {
-	pCell->RecalcAttributes(DWORD(-1));
+	pCell->RecalcAttributes(KeepCellLevel);
 	MapClass::Instance.ResetZones(pCell->MapCoords);
 	MapClass::Instance.RecalculateSubZones(pCell->MapCoords);
 }
@@ -109,7 +117,7 @@ static void BridgeCellDestroyed(CellClass* pCell)
 // type index still valid).
 static void BridgeCellDamaged(CellClass* pCell)
 {
-	pCell->RecalcAttributes(DWORD(-1));
+	pCell->RecalcAttributes(KeepCellLevel);
 	MapClass::Instance.RecalculateZones(pCell->MapCoords);
 	MapClass::Instance.RecalculateSubZones(pCell->MapCoords);
 }
@@ -121,7 +129,7 @@ static void BridgeCellDamaged(CellClass* pCell)
 DEFINE_HOOK(0x56EFF2, MapBridge_56EF50_RecalcCell, 0x7)
 {
 	GET(CellClass*, pCell, ESI);
-	pCell->OverlayTypeIndex = -1;
+	pCell->OverlayTypeIndex = NoOverlay;
 	BridgeCellDestroyed(pCell);
 	return 0x56EFF9;
 }
@@ -129,7 +137,7 @@ DEFINE_HOOK(0x56EFF2, MapBridge_56EF50_RecalcCell, 0x7)
 DEFINE_HOOK(0x56F392, MapBridge_56F2F0_RecalcCell, 0x7)
 {
 	GET(CellClass*, pCell, ESI);
-	pCell->OverlayTypeIndex = -1;
+	pCell->OverlayTypeIndex = NoOverlay;
 	BridgeCellDestroyed(pCell);
 	return 0x56F399;
 }
@@ -137,7 +145,7 @@ DEFINE_HOOK(0x56F392, MapBridge_56F2F0_RecalcCell, 0x7)
 DEFINE_HOOK(0x56F956, MapBridge_Destroy_56F8B0_RecalcCell, 0x7)
 {
 	GET(CellClass*, pCell, ESI);
-	pCell->OverlayTypeIndex = -1;
+	pCell->OverlayTypeIndex = NoOverlay;
 	BridgeCellDestroyed(pCell);
 	return 0x56F95D;
 }
@@ -145,7 +153,7 @@ DEFINE_HOOK(0x56F956, MapBridge_Destroy_56F8B0_RecalcCell, 0x7)
 DEFINE_HOOK(0x56FD26, MapBridge_56FCC0_RecalcCell, 0x7)
 {
 	GET(CellClass*, pCell, ESI);
-	pCell->OverlayTypeIndex = -1;
+	pCell->OverlayTypeIndex = NoOverlay;
 	BridgeCellDestroyed(pCell);
 	return 0x56FD2D;
 }
@@ -153,7 +161,7 @@ DEFINE_HOOK(0x56FD26, MapBridge_56FCC0_RecalcCell, 0x7)
 DEFINE_HOOK(0x5721C2, MapBridge_572100_RecalcCell_A, 0x7)
 {
 	GET(CellClass*, pCell, ESI);
-	pCell->OverlayTypeIndex = -1;
+	pCell->OverlayTypeIndex = NoOverlay;
 	BridgeCellDestroyed(pCell);
 	return 0x5721C9;
 }
@@ -161,7 +169,7 @@ DEFINE_HOOK(0x5721C2, MapBridge_572100_RecalcCell_A, 0x7)
 DEFINE_HOOK(0x5724E2, MapBridge_572480_RecalcCell, 0x7)
 {
 	GET(CellClass*, pCell, ESI);
-	pCell->OverlayTypeIndex = -1;
+	pCell->OverlayTypeIndex = NoOverlay;
 	BridgeCellDestroyed(pCell);
 	return 0x5724E9;
 }
@@ -169,7 +177,7 @@ DEFINE_HOOK(0x5724E2, MapBridge_572480_RecalcCell, 0x7)
 DEFINE_HOOK(0x572882, MapBridge_572820_RecalcCell, 0x7)
 {
 	GET(CellClass*, pCell, ESI);
-	pCell->OverlayTypeIndex = -1;
+	pCell->OverlayTypeIndex = NoOverlay;
 	BridgeCellDestroyed(pCell);
 	return 0x572889;
 }
@@ -177,7 +185,7 @@ DEFINE_HOOK(0x572882, MapBridge_572820_RecalcCell, 0x7)
 DEFINE_HOOK(0x572E46, MapBridge_572DE0_RecalcCell, 0x7)
 {
 	GET(CellClass*, pCell, ESI);
-	pCell->OverlayTypeIndex = -1;
+	pCell->OverlayTypeIndex = NoOverlay;
 	BridgeCellDestroyed(pCell);
 	return 0x572E4D;
 }
@@ -185,7 +193,7 @@ DEFINE_HOOK(0x572E46, MapBridge_572DE0_RecalcCell, 0x7)
 DEFINE_HOOK(0x573216, MapBridge_5731B0_RecalcCell, 0x7)
 {
 	GET(CellClass*, pCell, ESI);
-	pCell->OverlayTypeIndex = -1;
+	pCell->OverlayTypeIndex = NoOverlay;
 	BridgeCellDestroyed(pCell);
 	return 0x57321D;
 }
@@ -193,7 +201,7 @@ DEFINE_HOOK(0x573216, MapBridge_5731B0_RecalcCell, 0x7)
 DEFINE_HOOK(0x57779F, MapBridge_577740_RecalcCell, 0x7)
 {
 	GET(CellClass*, pCell, ESI);
-	pCell->OverlayTypeIndex = -1;
+	pCell->OverlayTypeIndex = NoOverlay;
 	BridgeCellDestroyed(pCell);
 	return 0x5777A6;
 }
@@ -201,7 +209,7 @@ DEFINE_HOOK(0x57779F, MapBridge_577740_RecalcCell, 0x7)
 DEFINE_HOOK(0x5778BB, MapBridge_577860_RecalcCell, 0x7)
 {
 	GET(CellClass*, pCell, ESI);
-	pCell->OverlayTypeIndex = -1;
+	pCell->OverlayTypeIndex = NoOverlay;
 	BridgeCellDestroyed(pCell);
 	return 0x5778C2;
 }
@@ -302,7 +310,7 @@ DEFINE_HOOK(0x5777FC, MapBridge_577740_Damaged_ESI, 0x7)
 DEFINE_HOOK(0x74CBEE, VeinholeArea_Bridge_RecalcCell, 0x7)
 {
 	GET(CellClass*, pCell, EBP);
-	pCell->OverlayTypeIndex = -1;
+	pCell->OverlayTypeIndex = NoOverlay;
 	BridgeCellDestroyed(pCell);
 	return 0x74CBF5;
 }
@@ -315,7 +323,7 @@ DEFINE_HOOK(0x576721, MapBridge_576200_RecalcCell, 0xA)
 {
 	GET(CellClass*, pCell, ESI);
 	pCell->OverlayData = 0;
-	pCell->OverlayTypeIndex = -1;
+	pCell->OverlayTypeIndex = NoOverlay;
 	BridgeCellDestroyed(pCell);
 	return 0x57672B;
 }

--- a/src/Misc/Bugfixes.Desyncs.cpp
+++ b/src/Misc/Bugfixes.Desyncs.cpp
@@ -25,8 +25,6 @@
 // leaving LandType stale. This diverges between players when an aircraft
 // passes over the cell(s) which later leads to pathfinding differences.
 
-#ifdef IS_CNCNET_YR_VER
-
 #include <Utilities/Macro.h>
 #include <CellClass.h>
 #include <FootClass.h>
@@ -345,5 +343,3 @@ DEFINE_HOOK(0x70F1E3, TechnoClass_DrawBehind_InvisibleDesyncFix, 0x8)
 // TODO: Remove when Phobos Release is greater than 0.4.0.2
 // as that has a better fix for this.
 DEFINE_PATCH(0x5C0E30, 0xB0, 0x01)
-
-#endif

--- a/src/Misc/Bugfixes.OpenTopCloak.cpp
+++ b/src/Misc/Bugfixes.OpenTopCloak.cpp
@@ -1,0 +1,49 @@
+/**
+*  yrpp-spawner
+*
+*  Copyright(C) 2022-present CnCNet
+*
+*  This program is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation, either version 3 of the License, or
+*  (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with this program.If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef IS_CNCNET_YR_VER
+
+#include <Utilities/Macro.h>
+#include <FootClass.h>
+#include <WeaponTypeClass.h>
+
+// NOTE: Overrides incorrect Ares hook at the same address.
+// Simplified: always apply the cloak check without configurable open-topped behavior.
+DEFINE_HOOK(0x6FCA26, TechnoClass_CanFire_RevertAresOpenTopCloakFix, 0x6)
+{
+	enum { Continue = 0x6FCA36, NotApplicable = 0x6FCA5E };
+
+	GET(WeaponTypeClass*, pWeapon, EBX);
+
+	if (!pWeapon->DecloakToFire)
+		return NotApplicable;
+
+	GET(TechnoClass*, pThis, ESI);
+
+	R->EAX(pThis->CloakState);
+	return Continue;
+}
+
+// Prevent the transporter from decloaking when a passenger fires from an open-topped transport.
+//	DEFINE_HOOK(0x6FCD1D, TechnoClass_CanFire_OpenTopCloakFix, 0x5)
+//	{
+//		return 0;
+//	}
+
+#endif

--- a/src/Misc/InGameChat.cpp
+++ b/src/Misc/InGameChat.cpp
@@ -22,6 +22,11 @@
 #include <HouseClass.h>
 #include <Unsorted.h>
 
+#ifdef IS_CNCNET_YR_VER
+#include <MessageListClass.h>
+#include <Windows.h>
+#endif
+
 // This corrects the processing of Unicode player names
 // and prohibits incoming messages from players with whom chat is disabled
 
@@ -38,7 +43,94 @@ struct GlobalPacket_NetMessage
 	byte Color;
 	byte CRC;
 };
+
 #pragma pack(pop)
+
+#ifdef IS_CNCNET_YR_VER
+static bool inline IsDisableChatEnabled()
+{
+	return Spawner::Enabled && Spawner::GetConfig()->DisableChat;
+}
+
+// Don't send message to others when DisableChat is active.
+// Mirrors: hack 0x0055EF38, 0x0055EF3E in chat_disable.asm
+DEFINE_HOOK(0x55EF38, MessageSend_DisableChat, 0x6)
+{
+	static int LastDisableChatFeedbackFrame = -1000;
+
+	if (IsDisableChatEnabled())
+	{
+		const int currentFrame = Unsorted::CurrentFrame;
+
+		if (currentFrame < LastDisableChatFeedbackFrame)
+			LastDisableChatFeedbackFrame = -1000; // new match started
+
+		if (currentFrame - LastDisableChatFeedbackFrame >= 90)
+		{
+			MessageListClass::Instance.PrintMessage(L"Chat is disabled. Message not sent.");
+			LastDisableChatFeedbackFrame = currentFrame;
+		}
+
+		return 0x55F056; // skip the send
+	}
+
+	return 0; // execute original: cmp edi, ebx; mov [esp+0x14], ebx
+}
+
+// After receiving a message, don't play sound if AddMessage returned NULL
+// (i.e. the message was suppressed). Mirrors: hack 0x0048D97E in chat_disable.asm
+DEFINE_HOOK(0x48D97E, NetworkCallBack_NetMessage_Sound, 0x5)
+{
+	if (!Spawner::Enabled)
+		return 0;
+
+	if (!R->EAX<void*>())
+		return 0x48D99A; // skip sound
+
+	return 0; // execute original: mov eax, [0x8871E0]
+}
+
+// In diplomacy dialog, make chat checkbox non-interactive for each player,
+// matching the existing Player_MuteSWLaunches disabled-checkbox behavior.
+// Replaces `mov eax, Player_MuteSWLaunches` (5 bytes at 0x657F8E).
+// The subsequent `push 0; test eax, eax; jnz 0x657FC0` remains intact and
+// branches to the disabled-checkbox path when EAX is non-zero.
+DEFINE_HOOK(0x657F8E, RadarClass_Diplomacy_DisableChatToggleUI, 0x5)
+{
+	R->EAX(IsDisableChatEnabled() ? 1 : Unsorted::MuteSWLaunches);
+	return 0;
+}
+
+// The non-interactive branch (loc_657FC0) sets BM_SETCHECK(1) before disabling.
+// Force it back to OFF for DisableChat so visuals match the intended locked state.
+DEFINE_HOOK(0x657FDB, RadarClass_Diplomacy_ForceDisabledChatVisualOff, 0x5)
+{
+	if (IsDisableChatEnabled())
+	{
+		GET(HWND, hWnd, EBP);
+		SendMessageA(hWnd, BM_SETCHECK, BST_UNCHECKED, 0);
+	}
+
+	return 0;
+}
+
+// Continuously enforce DisableChat by resetting ChatMask every frame,
+// preventing re-enabling chat from the alliance menu.
+DEFINE_HOOK(0x55DDA5, MainLoop_AfterRender_DisableChat, 0x5)
+{
+	auto const Original = reinterpret_cast<int(__thiscall*)(void*)>(0x5D4430);
+	GET(void*, pThis, ECX);
+	Original(pThis);
+
+	if (IsDisableChatEnabled())
+	{
+		for (int i = 0; i < 8; ++i)
+			Game::ChatMask[i] = false;
+	}
+
+	return 0x55DDAA;
+}
+#endif
 
 DEFINE_HOOK(0x48D92B, NetworkCallBack_NetMessage_Print, 0x5)
 {
@@ -46,6 +138,11 @@ DEFINE_HOOK(0x48D92B, NetworkCallBack_NetMessage_Print, 0x5)
 		return 0;
 
 	enum { SkipMessage = 0x48DAD3, PrintMessage = 0x48D937 };
+
+#ifdef IS_CNCNET_YR_VER
+	if (IsDisableChatEnabled())
+		return SkipMessage;
+#endif
 
 	const int houseIndex = GlobalPacket_NetMessage::Instance.HouseIndex;
 

--- a/src/Spawner/Spawner.Config.cpp
+++ b/src/Spawner/Spawner.Config.cpp
@@ -118,6 +118,9 @@ void SpawnerConfig::LoadFromINIFile(CCINIClass* pINI)
 		ContinueWithoutHumans    = pINI->ReadBool(pSettingsSection, "ContinueWithoutHumans", ContinueWithoutHumans);
 		DefeatedBecomesObserver  = pINI->ReadBool(pSettingsSection, "DefeatedBecomesObserver", DefeatedBecomesObserver);
 		Observer_ShowAIOnSidebar = pINI->ReadBool(pSettingsSection, "Observer.ShowAIOnSidebar", Observer_ShowAIOnSidebar);
+#ifdef IS_CNCNET_YR_VER
+		DisableChat              = pINI->ReadBool(pSettingsSection, "DisableChat", DisableChat);
+#endif
 	}
 }
 

--- a/src/Spawner/Spawner.Config.h
+++ b/src/Spawner/Spawner.Config.h
@@ -147,6 +147,9 @@ public:
 	bool ContinueWithoutHumans;
 	bool DefeatedBecomesObserver;
 	bool Observer_ShowAIOnSidebar;
+#ifdef IS_CNCNET_YR_VER
+	bool DisableChat;
+#endif
 
 	SpawnerConfig() // default values
 		// Game Mode Options
@@ -242,6 +245,9 @@ public:
 		, ContinueWithoutHumans { false }
 		, DefeatedBecomesObserver { false }
 		, Observer_ShowAIOnSidebar { false }
+#ifdef IS_CNCNET_YR_VER
+		, DisableChat { false }
+#endif
 	{ }
 
 	void LoadFromINIFile(CCINIClass* pINI);


### PR DESCRIPTION
Adds the current CnCNet YR spawner fixes behind the existing `IS_CNCNET_YR_VER` so they are only included in CnCNet YR builds.

Includes:
- DisableChat spawner config and in-game chat enforcement
- Open-top cloak fix
- Desync fixes


Can be deleted once this is merged:
https://github.com/CnCNet/yrpp-spawner/tree/current-cncnet-yr-build