### PR TITLE
Fix desync caused by graphics drivers corrupting the SSE control register

### DIFF
--- a/Spawner.vcxproj
+++ b/Spawner.vcxproj
@@ -81,6 +81,7 @@
     <!-- CnCNetYR -->
     <ClInclude Include="$(ThisDir)\src\CnCNetYR\Ra2Mode.h" />
     <!-- Misc -->
+    <ClInclude Include="$(ThisDir)\src\Misc\Bugfixes.Desyncs.h" />
     <ClInclude Include="$(ThisDir)\src\UI\Dialogs.h" />
     <!-- Spawner -->
     <ClInclude Include="$(ThisDir)\src\Spawner\NetHack.h" />

--- a/src/Misc/Bugfixes.Desyncs.cpp
+++ b/src/Misc/Bugfixes.Desyncs.cpp
@@ -26,10 +26,13 @@
 // passes over the cell(s) which later leads to pathfinding differences.
 
 #include <Utilities/Macro.h>
+#include <Utilities/Debug.h>
 #include <CellClass.h>
 #include <FootClass.h>
 #include <MapClass.h>
 #include <TechnoClass.h>
+
+#include <intrin.h>
 
 // CellClass::RecalcAttributes takes a cell level; -1 means "recalc but keep the
 // current level unchanged" (see CellClass.h).
@@ -351,3 +354,59 @@ DEFINE_HOOK(0x70F1E3, TechnoClass_DrawBehind_InvisibleDesyncFix, 0x8)
 // TODO: Remove when Phobos Release is greater than 0.4.0.2
 // as that has a better fix for this.
 DEFINE_PATCH(0x5C0E30, 0xB0, 0x01)
+
+// ============================================================
+// SSE FP-state (MXCSR) desync fix - renderer/GPU driver
+// ============================================================
+// On some machines the GPU driver corrupts the game thread's SSE control
+// register (MXCSR). Confirmed with Intel D3D9-on-D3D12 UMD (igd9trinity32.dll):
+// cnc-ddraw creates its D3D9 device synchronously on the game thread inside
+// IDirectDraw::SetDisplayMode, and the driver's CreateDevice returns with
+// MXCSR rounding control flipped from round-to-nearest (0x1F80) to
+// round-toward-zero (0x7FA0).
+//
+// The vanilla game is pure x87 and immune, but everything compiled with SSE
+// (this spawner, Phobos, Ares) then computes differently from every other
+// player: '100%' parses as 0.99999994f instead of 1.0f, that lands in
+// Ground.Cost -> movement speed -> desync as soon as a unit moves.
+//
+// Fixed:
+//  1. right after SetDisplayMode returns - kills the observed corruption at
+//     the source, before any INI parsing
+//  2. at Spawner::StartGame
+//  3. at the start of every logic frame - covers mid-game corruption
+
+namespace FPStateGuard
+{
+	static constexpr unsigned int DangerMask = 0xE040;
+	static constexpr unsigned int DefaultMxcsr = 0x1F80;
+
+	void Repair(const char* pSite)
+	{
+		const unsigned int mxcsr = _mm_getcsr();
+		if ((mxcsr & DangerMask) == 0)
+			return;
+
+		_mm_setcsr(DefaultMxcsr);
+
+		static int logged = 0;
+		if (logged < 10)
+		{
+			++logged;
+			Debug::Log("[Spawner] Repaired corrupted SSE FP state at %s: MXCSR %04X -> %04X (GPU driver bug, see cnc-ddraw#453)\n",
+				pSite, mxcsr & 0xFFFF, DefaultMxcsr);
+		}
+	}
+}
+
+DEFINE_HOOK(0x4A4420, SetVideoMode_RepairFPState, 0x9)
+{
+	FPStateGuard::Repair("SetDisplayMode");
+	return 0;
+}
+
+DEFINE_HOOK(0x55B4E1, LogicClass_Update_RepairFPState, 0x5)
+{
+	FPStateGuard::Repair("LogicFrameBegin");
+	return 0;
+}

--- a/src/Misc/Bugfixes.Desyncs.h
+++ b/src/Misc/Bugfixes.Desyncs.h
@@ -1,0 +1,27 @@
+/**
+*  yrpp-spawner
+*
+*  Copyright(C) 2022-present CnCNet
+*
+*  This program is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation, either version 3 of the License, or
+*  (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with this program.If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+namespace FPStateGuard
+{
+	// Restores the SSE control register (MXCSR) to its default if a
+	// renderer/GPU driver corrupted it (see Bugfixes.Desyncs.cpp).
+	void Repair(const char* pSite);
+}

--- a/src/Spawner/Spawner.cpp
+++ b/src/Spawner/Spawner.cpp
@@ -24,6 +24,7 @@
 #include "ProtocolZero.LatencyLevel.h"
 #include <Utilities/Debug.h>
 #include <Utilities/DumperTypes.h>
+#include <Misc/Bugfixes.Desyncs.h>
 
 #include <GameOptionsClass.h>
 #include <GameStrings.h>
@@ -64,6 +65,8 @@ bool Spawner::StartGame()
 	Spawner::Active = true;
 	Game::IsActive = true;
 	Game::InitUIStuff();
+
+	FPStateGuard::Repair("Spawner::StartGame");
 
 	char* pScenarioName = Config->ScenarioName;
 


### PR DESCRIPTION
Some graphics drivers return from D3D9 calls with the calling thread's MXCSR modified and never restore it.

From the attached logs, the rounding mode is changed during that call:

**Bad:** SetVideoMode-after-SetDisplayMode MXCSR=7FA0(rc=ZERO) x87CW=0E7F(rc=ZERO,pc=53)  
vs
**Good:** SetVideoMode-after-SetDisplayMode MXCSR=1FA0(rc=nearest) x87CW=0E7F(rc=ZERO,pc=53)

rc=ZERO means SSE math truncates instead of rounding to nearest. Phobos replaces INIClass::ReadDouble (0x5283D0) with an SSE implementation, so percentage values parse low on the affected machine:

`[Sidebar]HarvesterCounter.ConditionRed=50%:` **0.49999997** (should be 0.5)
`[Road]Hover=75%:` **0.74999994** (should be 0.75)

[debug_bad.log](https://github.com/user-attachments/files/30266581/debug_bad.log)
[debug_good.log](https://github.com/user-attachments/files/30266583/debug_good.log)

Fixed by restoring the SSE control register (MXCSR) right after SetDisplayMode, which is where it actually gets flipped and before before INIClass::ReadDouble runs. Also restore it at the start of every logic frame in case it happens mid-game.
