### PR TITLE
Regarding the content of Statistics, yrpp-spawner will now also support it, and computer players can also be tracked.

### DIFF
--- a/src/Spawner/Spawner.Config.cpp
+++ b/src/Spawner/Spawner.Config.cpp
@@ -114,6 +114,7 @@ void SpawnerConfig::LoadFromINIFile(CCINIClass* pINI)
 		QuickMatch               = pINI->ReadBool(pSettingsSection, "QuickMatch", QuickMatch);
 		SkipScoreScreen          = pINI->ReadBool(pSettingsSection, "SkipScoreScreen", SkipScoreScreen);
 		WriteStatistics          = pINI->ReadBool(pSettingsSection, "WriteStatistics", WriteStatistics);
+		GenerateStatistics       = pINI->ReadBool(pSettingsSection, "GenerateStatistics", GenerateStatistics);
 		AINamesByDifficulty      = pINI->ReadBool(pSettingsSection, "AINamesByDifficulty", AINamesByDifficulty);
 		ContinueWithoutHumans    = pINI->ReadBool(pSettingsSection, "ContinueWithoutHumans", ContinueWithoutHumans);
 		DefeatedBecomesObserver  = pINI->ReadBool(pSettingsSection, "DefeatedBecomesObserver", DefeatedBecomesObserver);

--- a/src/Spawner/Spawner.Config.h
+++ b/src/Spawner/Spawner.Config.h
@@ -143,6 +143,7 @@ public:
 	bool QuickMatch;
 	bool SkipScoreScreen;
 	bool WriteStatistics;
+	bool GenerateStatistics;
 	bool AINamesByDifficulty;
 	bool ContinueWithoutHumans;
 	bool DefeatedBecomesObserver;
@@ -241,6 +242,7 @@ public:
 		, QuickMatch { false }
 		, SkipScoreScreen { Main::GetConfig()->SkipScoreScreen }
 		, WriteStatistics { false }
+		, GenerateStatistics { true }
 		, AINamesByDifficulty { false }
 		, ContinueWithoutHumans { false }
 		, DefeatedBecomesObserver { false }

--- a/src/Spawner/Statistics.cpp
+++ b/src/Spawner/Statistics.cpp
@@ -20,6 +20,7 @@
 #include "Spawner.h"
 
 #include <CCFileClass.h>
+#include <FPSCounter.h>
 #include <HouseClass.h>
 #include <PacketClass.h>
 #include <ScenarioClass.h>
@@ -28,6 +29,10 @@
 #include <Utilities/Debug.h>
 #include <Utilities/Macro.h>
 
+#include <cstdio>
+#include <cstring>
+#include <Windows.h>
+
 bool __forceinline IsStatisticsEnabled()
 {
 	return Spawner::Active
@@ -35,7 +40,84 @@ bool __forceinline IsStatisticsEnabled()
 		&& !SessionClass::IsCampaign();
 }
 
-// Write stats.dmp
+static void WriteDTALog()
+{
+	if (!Spawner::Active)
+		return;
+
+	if (!Spawner::GetConfig()->GenerateStatistics)
+		return;
+
+	CreateDirectoryA("debug", nullptr);
+
+	CCFileClass file = CCFileClass("debug\\Statistic.log");
+	if (!file.Open(FileAccessMode::Write))
+		return;
+
+	using GetUnitCountFunc = int(__fastcall*)(void*);
+	const auto GetUnitCount = reinterpret_cast<GetUnitCountFunc>(0x49FB60);
+
+	const int count = HouseClass::Array.Count;
+
+	for (int i = 0; i < count; i++)
+	{
+		const auto pHouse = HouseClass::Array.GetItem(i);
+		if (!pHouse)
+			continue;
+
+		if (pHouse->Type && pHouse->Type->MultiplayPassive)
+			continue;
+
+		if (pHouse->IsInitiallyObserver())
+			continue;
+
+		char name[64] = { 0 };
+		if (pHouse->IsHumanPlayer)
+		{
+			WideCharToMultiByte(CP_UTF8, 0, pHouse->UIName, -1, name, sizeof(name), nullptr, nullptr);
+		}
+		else
+		{
+			strcpy_s(name, "Computer");
+		}
+
+		const char* result = pHouse->Defeated ? "Loser" : "Winner";
+
+		int lost = *reinterpret_cast<const int*>(
+			reinterpret_cast<const char*>(pHouse) + 21556)
+			+ *reinterpret_cast<const int*>(
+				reinterpret_cast<const char*>(pHouse) + 21640);
+
+		const int* k1 = reinterpret_cast<const int*>(
+			reinterpret_cast<const char*>(pHouse) + 21476);
+		const int* k2 = reinterpret_cast<const int*>(
+			reinterpret_cast<const char*>(pHouse) + 21560);
+		int kills = 0;
+		for (int j = 0; j < 20; ++j) kills += k1[j];
+		for (int j = 0; j < 20; ++j) kills += k2[j];
+
+		int built = GetUnitCount(reinterpret_cast<char*>(pHouse) + 21920)
+			+ GetUnitCount(reinterpret_cast<char*>(pHouse) + 21940)
+			+ GetUnitCount(reinterpret_cast<char*>(pHouse) + 21960)
+			+ GetUnitCount(reinterpret_cast<char*>(pHouse) + 21980);
+
+		int score = *reinterpret_cast<const int*>(
+			reinterpret_cast<const char*>(pHouse) + 21736);
+
+		char buffer[256] = { 0 };
+		sprintf_s(buffer, "%s: %s\n Lost = %d\n Kills = %d\n Built = %d\n Score = %d\n",
+			name, result, lost, kills, built, score);
+		file.WriteBytes(buffer, static_cast<int>(strlen(buffer)));
+	}
+
+	char fpsBuffer[128] = { 0 };
+	sprintf_s(fpsBuffer, "Game loop finished. Average FPS = %d\n",
+		static_cast<int>(FPSCounter::GetAverageFrameRate()));
+	file.WriteBytes(fpsBuffer, static_cast<int>(strlen(fpsBuffer)));
+
+	file.Close();
+}
+
 DEFINE_HOOK(0x6C856C, SendStatisticsPacket_WriteStatisticsDump, 0x5)
 {
 	if (IsStatisticsEnabled())
@@ -50,12 +132,20 @@ DEFINE_HOOK(0x6C856C, SendStatisticsPacket_WriteStatisticsDump, 0x5)
 			statsFile.Close();
 		}
 
+		WriteDTALog();
+
 		bool& bStatisticsPacketSent = *reinterpret_cast<bool*>(0xA8F900);
 		bStatisticsPacketSent = true;
 
 		return 0x6C87B8;
 	}
 
+	return 0;
+}
+
+DEFINE_HOOK(0x5C9D47, MPScore_InitDialog_WriteDTALog, 0x6)
+{
+	WriteDTALog();
 	return 0;
 }
 

--- a/src/Spawner/Statistics.cpp
+++ b/src/Spawner/Statistics.cpp
@@ -29,6 +29,31 @@
 #include <Utilities/Debug.h>
 #include <Utilities/Macro.h>
 
+
+// MP score global statistics array, populated by the original sub_5C98A0
+// during MPScore_InitDialog. The in-game score screen reads from the same
+// array, so reading it here guarantees DTA.LOG matches the in-game display
+// exactly (including Score's if(>0) filter and the winner bonus).
+// Each record is 112 bytes with 16-byte field spacing (Westwood-style align).
+struct MPScoreStatsEntry
+{
+	wchar_t Name[20];   // 0x00 Player name (copy of pHouse->UIName)
+	int    Scheme;      // 0x28 Scenario index
+	int    Winner;      // 0x2C 1=winner 0=loser
+	int    Lost;        // 0x30 Lost = TotalKilledUnits + TotalKilledBuildings
+	int    _pad0[3];    // 0x34
+	int    Kills;       // 0x40 Kills = sum(KilledUnitsOfHouses) + sum(KilledBuildingsOfHouses)
+	int    _pad1[3];    // 0x44
+	int    Built;       // 0x50 Built = sum of 4 FactoryProduced*Types.GetTotal()
+	int    _pad2[3];    // 0x54
+	int    Score;       // 0x60 Score (with if(>0) filter and winner bonus applied)
+	int    _pad3[3];    // 0x64
+};
+static_assert(sizeof(MPScoreStatsEntry) == 112, "MPScoreStatsEntry size mismatch");
+
+DEFINE_POINTER(MPScoreStatsEntry, MPScoreStatsArray, 0xA8D1FCu)
+DEFINE_POINTER(int, MPScoreStatsCount, 0xA8D580u)
+
 bool __forceinline IsStatisticsEnabled()
 {
 	return Spawner::Active
@@ -50,49 +75,23 @@ static void WriteDTALog()
 	if (!file.Open(FileAccessMode::Write))
 		return;
 
-	const int count = HouseClass::Array.Count;
+	// Read from the global array populated by sub_5C98A0, the same data
+	// source as the in-game score screen. The array is filled after
+	// MPScore_InitDialog (0x5C9D42) calls sub_5C98A0.
+	const int count = *MPScoreStatsCount;
 
 	for (int i = 0; i < count; i++)
 	{
-		const auto pHouse = HouseClass::Array.GetItem(i);
-		if (!pHouse)
-			continue;
-
-		if (pHouse->Type && pHouse->Type->MultiplayPassive)
-			continue;
-
-		if (pHouse->IsInitiallyObserver())
-			continue;
+		const auto& entry = MPScoreStatsArray[i];
 
 		char name[64] = { 0 };
-		if (pHouse->IsHumanPlayer)
-		{
-			WideCharToMultiByte(CP_UTF8, 0, pHouse->UIName, -1, name, sizeof(name), nullptr, nullptr);
-		}
-		else
-		{
-			strcpy_s(name, "Computer");
-		}
+		WideCharToMultiByte(CP_UTF8, 0, entry.Name, -1, name, sizeof(name), nullptr, nullptr);
 
-		const char* result = pHouse->Defeated ? "Loser" : "Winner";
-
-
-		int lost = pHouse->TotalKilledUnits + pHouse->TotalKilledBuildings;
-
-		int kills = 0;
-		for (int j = 0; j < 20; ++j) kills += pHouse->KilledUnitsOfHouses[j];
-		for (int j = 0; j < 20; ++j) kills += pHouse->KilledBuildingsOfHouses[j];
-
-		int built = pHouse->FactoryProducedBuildingTypes.GetTotal()
-			+ pHouse->FactoryProducedUnitTypes.GetTotal()
-			+ pHouse->FactoryProducedInfantryTypes.GetTotal()
-			+ pHouse->FactoryProducedAircraftTypes.GetTotal();
-
-		int score = pHouse->PointTotal;
+		const char* result = entry.Winner ? "Winner" : "Loser";
 
 		char buffer[256] = { 0 };
 		sprintf_s(buffer, "%s: %s\n Lost = %d\n Kills = %d\n Built = %d\n Score = %d\n",
-			name, result, lost, kills, built, score);
+			name, result, entry.Lost, entry.Kills, entry.Built, entry.Score);
 		file.WriteBytes(buffer, static_cast<int>(strlen(buffer)));
 	}
 
@@ -118,8 +117,6 @@ DEFINE_HOOK(0x6C856C, SendStatisticsPacket_WriteStatisticsDump, 0x5)
 			statsFile.Close();
 		}
 
-		WriteDTALog();
-
 		bool& bStatisticsPacketSent = *reinterpret_cast<bool*>(0xA8F900);
 		bStatisticsPacketSent = true;
 
@@ -131,6 +128,9 @@ DEFINE_HOOK(0x6C856C, SendStatisticsPacket_WriteStatisticsDump, 0x5)
 
 DEFINE_HOOK(0x5C9D47, MPScore_InitDialog_WriteDTALog, 0x6)
 {
+	// sub_5C98A0 has just finished (called at 0x5C9D42), so the global
+	// statistics array is now populated with the exact same Score shown
+	// in-game (including the if(>0) filter and the winner bonus).
 	WriteDTALog();
 	return 0;
 }

--- a/src/Spawner/Statistics.cpp
+++ b/src/Spawner/Statistics.cpp
@@ -103,6 +103,7 @@ static void WriteDTALog()
 	file.Close();
 }
 
+// Write stats.dmp
 DEFINE_HOOK(0x6C856C, SendStatisticsPacket_WriteStatisticsDump, 0x5)
 {
 	if (IsStatisticsEnabled())

--- a/src/Spawner/Statistics.cpp
+++ b/src/Spawner/Statistics.cpp
@@ -30,29 +30,10 @@
 #include <Utilities/Macro.h>
 
 
-// MP score global statistics array, populated by the original sub_5C98A0
-// during MPScore_InitDialog. The in-game score screen reads from the same
-// array, so reading it here guarantees DTA.LOG matches the in-game display
-// exactly (including Score's if(>0) filter and the winner bonus).
-// Each record is 112 bytes with 16-byte field spacing (Westwood-style align).
-struct MPScoreStatsEntry
-{
-	wchar_t Name[20];   // 0x00 Player name (copy of pHouse->UIName)
-	int    Scheme;      // 0x28 Scenario index
-	int    Winner;      // 0x2C 1=winner 0=loser
-	int    Lost;        // 0x30 Lost = TotalKilledUnits + TotalKilledBuildings
-	int    _pad0[3];    // 0x34
-	int    Kills;       // 0x40 Kills = sum(KilledUnitsOfHouses) + sum(KilledBuildingsOfHouses)
-	int    _pad1[3];    // 0x44
-	int    Built;       // 0x50 Built = sum of 4 FactoryProduced*Types.GetTotal()
-	int    _pad2[3];    // 0x54
-	int    Score;       // 0x60 Score (with if(>0) filter and winner bonus applied)
-	int    _pad3[3];    // 0x64
-};
-static_assert(sizeof(MPScoreStatsEntry) == 112, "MPScoreStatsEntry size mismatch");
-
-DEFINE_POINTER(MPScoreStatsEntry, MPScoreStatsArray, 0xA8D1FCu)
-DEFINE_POINTER(int, MPScoreStatsCount, 0xA8D580u)
+// MAX_MULTI_GAMES index used by the single-result MP score screen.
+// The array supports multi-game (tournament) accumulation, but in RA2/YR's
+// standard non-tournament MPScore dialog sub_5C98A0 only writes slot 0.
+static constexpr int ScoreGameSlot = 0;
 
 bool __forceinline IsStatisticsEnabled()
 {
@@ -75,23 +56,28 @@ static void WriteDTALog()
 	if (!file.Open(FileAccessMode::Write))
 		return;
 
-	// Read from the global array populated by sub_5C98A0, the same data
-	// source as the in-game score screen. The array is filled after
+	// Read from the SessionClass::MPScores array populated by sub_5C98A0, the
+	// same data source as the in-game score screen. The array is filled after
 	// MPScore_InitDialog (0x5C9D42) calls sub_5C98A0.
-	const int count = *MPScoreStatsCount;
+	const int count = SessionClass::MPScoreCount;
 
 	for (int i = 0; i < count; i++)
 	{
-		const auto& entry = MPScoreStatsArray[i];
+		const auto& entry = SessionClass::MPScores[i];
 
 		char name[64] = { 0 };
 		WideCharToMultiByte(CP_UTF8, 0, entry.Name, -1, name, sizeof(name), nullptr, nullptr);
 
-		const char* result = entry.Winner ? "Winner" : "Loser";
+		const char* result = entry.Wins ? "Winner" : "Loser";
+
+		const int lost  = entry.Lost[ScoreGameSlot];
+		const int kills = entry.Kills[ScoreGameSlot];
+		const int built = entry.Built[ScoreGameSlot];
+		const int score = entry.Score[ScoreGameSlot];
 
 		char buffer[256] = { 0 };
 		sprintf_s(buffer, "%s: %s\n Lost = %d\n Kills = %d\n Built = %d\n Score = %d\n",
-			name, result, entry.Lost, entry.Kills, entry.Built, entry.Score);
+			name, result, lost, kills, built, score);
 		file.WriteBytes(buffer, static_cast<int>(strlen(buffer)));
 	}
 

--- a/src/Spawner/Statistics.cpp
+++ b/src/Spawner/Statistics.cpp
@@ -61,12 +61,30 @@ static void WriteDTALog()
 	// MPScore_InitDialog (0x5C9D42) calls sub_5C98A0.
 	const int count = SessionClass::MPScoreCount;
 
-	for (int i = 0; i < count; i++)
+	// Walk HouseClass::Array in the same order as sub_5C98A0 to map each
+	// MPScores entry back to its HouseClass, so we can tell human players
+	// from AI players. AI players are always named "Computer" regardless of
+	// the localised UIName the game copies into the score array.
+	int scoreIndex = 0;
+
+	for (auto pHouse : HouseClass::Array)
 	{
-		const auto& entry = SessionClass::MPScores[i];
+		// Same filter as sub_5C98A0: skip null, passive, and observer houses.
+		if (!pHouse
+			|| (pHouse->Type && pHouse->Type->MultiplayPassive)
+			|| pHouse->IsObserver())
+			continue;
+
+		if (scoreIndex >= count)
+			break;
+
+		const auto& entry = SessionClass::MPScores[scoreIndex];
+
+		const wchar_t* display_name = pHouse->IsHumanPlayer
+			? entry.Name : L"Computer";
 
 		char name[64] = { 0 };
-		WideCharToMultiByte(CP_UTF8, 0, entry.Name, -1, name, sizeof(name), nullptr, nullptr);
+		WideCharToMultiByte(CP_UTF8, 0, display_name, -1, name, sizeof(name), nullptr, nullptr);
 
 		const char* result = entry.Wins ? "Winner" : "Loser";
 
@@ -79,6 +97,8 @@ static void WriteDTALog()
 		sprintf_s(buffer, "%s: %s\n Lost = %d\n Kills = %d\n Built = %d\n Score = %d\n",
 			name, result, lost, kills, built, score);
 		file.WriteBytes(buffer, static_cast<int>(strlen(buffer)));
+
+		++scoreIndex;
 	}
 
 	char fpsBuffer[128] = { 0 };

--- a/src/Spawner/Statistics.cpp
+++ b/src/Spawner/Statistics.cpp
@@ -54,9 +54,6 @@ static void WriteDTALog()
 	if (!file.Open(FileAccessMode::Write))
 		return;
 
-	using GetUnitCountFunc = int(__fastcall*)(void*);
-	const auto GetUnitCount = reinterpret_cast<GetUnitCountFunc>(0x49FB60);
-
 	const int count = HouseClass::Array.Count;
 
 	for (int i = 0; i < count; i++)
@@ -83,26 +80,19 @@ static void WriteDTALog()
 
 		const char* result = pHouse->Defeated ? "Loser" : "Winner";
 
-		int lost = *reinterpret_cast<const int*>(
-			reinterpret_cast<const char*>(pHouse) + 21556)
-			+ *reinterpret_cast<const int*>(
-				reinterpret_cast<const char*>(pHouse) + 21640);
 
-		const int* k1 = reinterpret_cast<const int*>(
-			reinterpret_cast<const char*>(pHouse) + 21476);
-		const int* k2 = reinterpret_cast<const int*>(
-			reinterpret_cast<const char*>(pHouse) + 21560);
+		int lost = pHouse->TotalKilledUnits + pHouse->TotalKilledBuildings;
+
 		int kills = 0;
-		for (int j = 0; j < 20; ++j) kills += k1[j];
-		for (int j = 0; j < 20; ++j) kills += k2[j];
+		for (int j = 0; j < 20; ++j) kills += pHouse->KilledUnitsOfHouses[j];
+		for (int j = 0; j < 20; ++j) kills += pHouse->KilledBuildingsOfHouses[j];
 
-		int built = GetUnitCount(reinterpret_cast<char*>(pHouse) + 21920)
-			+ GetUnitCount(reinterpret_cast<char*>(pHouse) + 21940)
-			+ GetUnitCount(reinterpret_cast<char*>(pHouse) + 21960)
-			+ GetUnitCount(reinterpret_cast<char*>(pHouse) + 21980);
+		int built = pHouse->FactoryProducedBuildingTypes.GetTotal()
+			+ pHouse->FactoryProducedUnitTypes.GetTotal()
+			+ pHouse->FactoryProducedInfantryTypes.GetTotal()
+			+ pHouse->FactoryProducedAircraftTypes.GetTotal();
 
-		int score = *reinterpret_cast<const int*>(
-			reinterpret_cast<const char*>(pHouse) + 21736);
+		int score = pHouse->PointTotal;
 
 		char buffer[256] = { 0 };
 		sprintf_s(buffer, "%s: %s\n Lost = %d\n Kills = %d\n Built = %d\n Score = %d\n",

--- a/src/Spawner/Statistics.cpp
+++ b/src/Spawner/Statistics.cpp
@@ -29,10 +29,6 @@
 #include <Utilities/Debug.h>
 #include <Utilities/Macro.h>
 
-#include <cstdio>
-#include <cstring>
-#include <Windows.h>
-
 bool __forceinline IsStatisticsEnabled()
 {
 	return Spawner::Active


### PR DESCRIPTION
In addition to Ares' -Log, generating debug/Statistic.log is now supported as a new way to collect statistics, and AI players can also be tracked.

Supporting on/off functionality in spawn.ini
```
[Settings]
GenerateStatistics=yes
```

On the client side, you can choose to use this via ClientDefinitions.ini.
```
[Settings]
StatisticsLogFileName=debug\Statistic.log
```